### PR TITLE
fix: increase watchdog and SD init timeout for SDHC card compatibility

### DIFF
--- a/src/apps/sequencer/Sequencer.cpp
+++ b/src/apps/sequencer/Sequencer.cpp
@@ -150,7 +150,7 @@ static void assert_handler(const char *filename, int line, const char *msg) {
 
 int main(void) {
     System::init();
-    System::startWatchdog(1000);
+    System::startWatchdog(5000);
     Console::init();
     HighResolutionTimer::init();
 

--- a/src/platform/stm32/drivers/SdCard.cpp
+++ b/src/platform/stm32/drivers/SdCard.cpp
@@ -222,7 +222,7 @@ bool SdCard::initCard() {
     const uint32_t OCR_CCS = 0x40000000;
 
     bool acmd41_success = false;
-    uint32_t timeout = os::ticks() + os::time::ms(2000);
+    uint32_t timeout = os::ticks() + os::time::ms(4000);
     while (os::ticks() < timeout) {
         result = sendAppCommand(41, 0x100000 | (hcs ? OCR_HCS : 0));
         uint32_t response = SDIO_RESP1;


### PR DESCRIPTION
## Summary

- Increase watchdog timeout from 1000ms to 5000ms
- Increase ACMD41 SD init timeout from 2000ms to 4000ms

## Problem

Some SDHC cards (e.g. Samsung 16GB HC Class 10) take longer to initialize in SPI compatibility mode, causing:
1. **Boot loops** — progress bar fills, board resets repeatedly
2. **Crashes when loading projects** — works without SD, crashes on project load

## Root Cause

The 1000ms watchdog fires before `sdCard.init()` completes on slower cards. The 2000ms ACMD41 timeout is insufficient for some SDHC cards to complete their SPI init handshake.

Related: https://github.com/westlicht/performer/issues/368 and https://github.com/westlicht/performer/issues/397

## Testing

Tested on DIY build:
- ✅ Samsung 16GB HC Class 10 (previously failing, now works)
- ✅ SanDisk 8GB (was already working, still works)

Fixes #17